### PR TITLE
Adding map styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 1.4.3
+* ⭐️ Feature: New `/f style` command for changing map colours and characters of factions
+* ⌨️ API: `Faction#hasForcedMapCharacter` method added
+* ⌨️ API: `Faction#setForcedMapCharacter` method added
+* ⌨️ API: `Faction#getForcedMapCharacter` method added
+* ⌨️ API: `Faction#hasForcedMapColour` method added
+* ⌨️ API: `Faction#setForcedMapColour` method added
+* ⌨️ API: `Faction#getForcedMapColour` method added
+
 # 1.4.2
 * 🐞 Bugfix: PlaceholderAPI wasn't working properly, but it works now! 
 * 🐞 Bugfix: Factionless Scoreboards were not refreshing

--- a/src/main/java/net/redstoneore/legacyfactions/Lang.java
+++ b/src/main/java/net/redstoneore/legacyfactions/Lang.java
@@ -574,6 +574,15 @@ public enum Lang {
 	COMMAND_WARUNCLAIMALL_SUCCESS("<i>You unclaimed ALL war zone land."),
 	COMMAND_WARUNCLAIMALL_LOG("%1$s unclaimed all war zones."),
 
+	COMMAND_STYLE_DESCRIPTION("Set a factions styles"),
+	COMMAND_STYLE_ARG_CHARACTER("character"),
+	COMMAND_STYLE_ARG_COLOUR("color"),
+	COMMAND_STYLE_ARG_VALUE("value"),
+	COMMAND_STYLE_INVALIDSTYLE("<b>Invalid type, you can only set color or character!"),	
+	COMMAND_STYLE_INVALIDCOLOUR("<b>Invalid colour!"),	
+	COMMAND_STYLE_COLOURUPDATED("<i>Forced map colour set to <colour><i>."),	
+	COMMAND_STYLE_CHARACTERUPDATED("<i>Forced map character set to <character><i>."),	
+	
 	// -------------------------------------------------- //
 	// Leaving
 	// -------------------------------------------------- //

--- a/src/main/java/net/redstoneore/legacyfactions/Permission.java
+++ b/src/main/java/net/redstoneore/legacyfactions/Permission.java
@@ -94,6 +94,8 @@ public enum Permission {
 	TOP("top"),
 	VAULT("vault"),
 	SETMAXVAULTS("setmaxvaults"),
+	STYLE("style"),
+	STYLE_ANY("style.any");
 	;
 	
 	// -------------------------------------------------- //

--- a/src/main/java/net/redstoneore/legacyfactions/cmd/CmdFactions.java
+++ b/src/main/java/net/redstoneore/legacyfactions/cmd/CmdFactions.java
@@ -42,6 +42,7 @@ public class CmdFactions extends FCommand {
 		this.addSubCommand(CmdFactionsBoom.get());
 		this.addSubCommand(CmdFactionsBypass.get());
 		this.addSubCommand(CmdFactionsClaim.get());
+		this.addSubCommand(CmdFactionsClaimLine.get());
 		this.addSubCommand(CmdFactionsColeader.get());
 		this.addSubCommand(CmdFactionsConfig.get());
 		this.addSubCommand(CmdFactionsCreate.get());
@@ -79,6 +80,7 @@ public class CmdFactions extends FCommand {
 		this.addSubCommand(CmdFactionsShow.get());
 		this.addSubCommand(CmdFactionsStatus.get());
 		this.addSubCommand(CmdFactionsStuck.get());
+		this.addSubCommand(CmdFactionsStyle.get());
 		this.addSubCommand(CmdFactionsTag.get());
 		this.addSubCommand(CmdFactionsTitle.get());
 		this.addSubCommand(CmdFactionsUnclaim.get());
@@ -95,7 +97,6 @@ public class CmdFactions extends FCommand {
 		this.addSubCommand(CmdFactionsDelwarp.get());
 		this.addSubCommand(CmdFactionsModifyPower.get());
 		this.addSubCommand(CmdFactionsLogins.get());
-		this.addSubCommand(CmdFactionsClaimLine.get());
 		this.addSubCommand(CmdFactionsTop.get());
 	}
 	

--- a/src/main/java/net/redstoneore/legacyfactions/cmd/CmdFactionsStyle.java
+++ b/src/main/java/net/redstoneore/legacyfactions/cmd/CmdFactionsStyle.java
@@ -1,0 +1,89 @@
+package net.redstoneore.legacyfactions.cmd;
+
+import org.bukkit.ChatColor;
+
+import net.redstoneore.legacyfactions.Lang;
+import net.redstoneore.legacyfactions.Permission;
+import net.redstoneore.legacyfactions.entity.Conf;
+import net.redstoneore.legacyfactions.entity.Faction;
+import net.redstoneore.legacyfactions.util.TextUtil;
+
+public class CmdFactionsStyle extends FCommand {
+
+	// -------------------------------------------------- //
+	// INSTANCE
+	// -------------------------------------------------- //
+	
+	private static CmdFactionsStyle instance = new CmdFactionsStyle();
+	public static CmdFactionsStyle get() { return instance; }
+	
+	// -------------------------------------------------- //
+	// CONSTRUCT
+	// -------------------------------------------------- //
+
+	private CmdFactionsStyle() {
+		this.aliases.addAll(Conf.cmdAliasesStyle);
+
+		this.requiredArgs.add(Lang.COMMAND_STYLE_ARG_CHARACTER.toString() + "|" + Lang.COMMAND_STYLE_ARG_COLOUR.toString());
+		this.requiredArgs.add(Lang.COMMAND_STYLE_ARG_VALUE.toString());
+		this.optionalArgs.put("faction", "yours");
+		
+		this.permission = Permission.STYLE.getNode();
+		this.disableOnLock = true;
+
+		this.senderMustBePlayer = false;
+		this.senderMustBeMember = false;
+		this.senderMustBeModerator = false;
+		this.senderMustBeAdmin = false;
+	}
+	
+	// -------------------------------------------------- //
+	// METHODS
+	// -------------------------------------------------- //
+
+	@Override
+	public void perform() {
+		Faction targetFaction = this.argAsFaction(2, this.myFaction, true);
+		
+		if (targetFaction != this.myFaction && !Permission.STYLE_ANY.has(this.sender, true)) {
+			return;
+		}
+		
+		switch (this.argAsString(0).toLowerCase()) {
+		case "character":
+		case "char":
+			Character character = null;
+			character = this.argAsString(1).charAt(0);
+			
+			targetFaction.setForcedMapCharacter(character);
+			
+			this.sendMessage(TextUtil.parseColor(Lang.COMMAND_STYLE_CHARACTERUPDATED.toString().replace("<character>", character.toString())));
+			break;
+			
+		case "colour":
+		case "color":
+			ChatColor colour;
+			try {
+				colour = ChatColor.valueOf(this.argAsString(1));
+			} catch (Exception e) {
+				this.sendMessage(TextUtil.parseColor(Lang.COMMAND_STYLE_INVALIDCOLOUR.toString()));
+				return;
+			}
+			
+			targetFaction.setForcedMapColour(colour);
+			
+			this.sendMessage(TextUtil.parseColor(Lang.COMMAND_STYLE_COLOURUPDATED.toString().replace("<colour>", colour.name())));
+			break;
+			
+		default:
+			this.sendMessage(TextUtil.parseColor(Lang.COMMAND_STYLE_INVALIDSTYLE.toString()));
+			break;
+		}
+	}
+
+	@Override
+	public String getUsageTranslation() {
+		return Lang.COMMAND_STYLE_DESCRIPTION.toString();
+	}
+
+}

--- a/src/main/java/net/redstoneore/legacyfactions/entity/Conf.java
+++ b/src/main/java/net/redstoneore/legacyfactions/entity/Conf.java
@@ -69,7 +69,6 @@ public class Conf {
 	public static ChatColor colorEnemy = ChatColor.RED;
 
 	public static ChatColor colorPeaceful = ChatColor.GOLD;
-	public static ChatColor colorWar = ChatColor.DARK_RED;
 
 	// -------------------------------------------------- //
  	// TOOLTIPS
@@ -830,7 +829,8 @@ public class Conf {
 	public static List<String> cmdAliasesVersion = Lists.newArrayList("version");
 	public static List<String> cmdAliasesWarp = Lists.newArrayList("warp", "warps");
 	public static List<String> cmdAliasesWarunclaimall = Lists.newArrayList("warunclaimall");
-		
+	public static List<String> cmdAliasesStyle = Lists.newArrayList("style");	
+	
 	// -------------------------------------------- //
 	// Persistance
 	// -------------------------------------------- //

--- a/src/main/java/net/redstoneore/legacyfactions/entity/Faction.java
+++ b/src/main/java/net/redstoneore/legacyfactions/entity/Faction.java
@@ -77,6 +77,18 @@ public interface Faction extends EconomyParticipator {
 
 	void setDescription(String value);
 
+	boolean hasForcedMapCharacter();
+	
+	void setForcedMapCharacter(char character);
+	
+	Character getForcedMapCharacter();
+	
+	boolean hasForcedMapColour();
+	
+	void setForcedMapColour(ChatColor colour);
+	
+	ChatColor getForcedMapColour();
+	
 	void setHome(Location home);
 
 	boolean hasHome();

--- a/src/main/java/net/redstoneore/legacyfactions/entity/persist/memory/MemoryBoard.java
+++ b/src/main/java/net/redstoneore/legacyfactions/entity/persist/memory/MemoryBoard.java
@@ -290,24 +290,32 @@ public abstract class MemoryBoard extends Board {
                     FLocation flocationHere = topLeft.getRelative(dx, dz);
                     Faction factionHere = getFactionAt(flocationHere);
                     Relation relation = faction.getRelationTo(factionHere);
-                    if (factionHere.isWilderness()) {
-                        row += ChatColor.GRAY + "-";
-                    } else if (factionHere.isSafeZone()) {
-                        row += Conf.colorPeaceful + "+";
-                    } else if (factionHere.isWarZone()) {
-                        row += ChatColor.DARK_RED + "+";
+                    
+                    // Wilderness, safezone, and warzone all have forced colours and characters
+                    if (factionHere.isWilderness() || factionHere.isSafeZone() || factionHere.isWarZone()) {
+                        row += factionHere.getForcedMapColour() + "" + factionHere.getForcedMapCharacter();
                     } else if (factionHere == faction ||
                                        factionHere == factionLoc ||
                                        relation.isAtLeast(Relation.ALLY) ||
                                        (Conf.showNeutralFactionsOnMap && relation.equals(Relation.NEUTRAL)) ||
                                        (Conf.showEnemyFactionsOnMap && relation.equals(Relation.ENEMY))) {
                         if (!fList.containsKey(factionHere.getTag())) {
-                            fList.put(factionHere.getTag(), Conf.mapKeyChrs[Math.min(chrIdx++, Conf.mapKeyChrs.length - 1)]);
+                        	if (factionHere.hasForcedMapCharacter()) {
+                                fList.put(factionHere.getTag(), factionHere.getForcedMapCharacter());                        		
+                        	} else {
+                                fList.put(factionHere.getTag(), Conf.mapKeyChrs[Math.min(chrIdx++, Conf.mapKeyChrs.length - 1)]);                        		
+                        	}
                         }
-                        char tag = fList.get(factionHere.getTag());
-                        row += factionHere.getColorTo(faction) + "" + tag;
+                        char mapCharacter = fList.get(factionHere.getTag());
+                        
+                        if (factionHere.hasForcedMapColour()){
+                            row += factionHere.getForcedMapColour() + "" + mapCharacter;
+                        } else {
+                            row += factionHere.getColorTo(faction) + "" + mapCharacter;                        	
+                        }
                     } else {
-                        row += ChatColor.GRAY + "-";
+                    	// Assume wilderness
+                    	row += FactionColl.get().getWilderness().getForcedMapColour() + "" + FactionColl.get().getWilderness().getForcedMapCharacter();
                     }
                 }
             }

--- a/src/main/java/net/redstoneore/legacyfactions/entity/persist/memory/MemoryFaction.java
+++ b/src/main/java/net/redstoneore/legacyfactions/entity/persist/memory/MemoryFaction.java
@@ -43,6 +43,8 @@ public abstract class MemoryFaction implements Faction, EconomyParticipator {
 	protected boolean permanent;
 	protected String tag;
 	protected String description;
+	protected Character forcedMapCharacter = null;
+	protected ChatColor forcedMapColour = null;
 	protected boolean open;
 	protected boolean peaceful;
 	protected Integer permanentPower;
@@ -257,6 +259,51 @@ public abstract class MemoryFaction implements Faction, EconomyParticipator {
 	public void setDescription(String value) {
 		this.description = value;
 	}
+
+	public boolean hasForcedMapCharacter() {
+		return this.getForcedMapCharacter() != null;
+	}
+	
+	public void setForcedMapCharacter(char character) {
+		this.forcedMapCharacter = character;
+	}
+	
+	public Character getForcedMapCharacter() {
+		if (this.isWilderness() && this.forcedMapCharacter == null) {
+			this.forcedMapCharacter = "-".charAt(0);
+		}
+		if (this.isSafeZone() && this.forcedMapCharacter == null) {
+			this.forcedMapCharacter = "+".charAt(0);
+		}
+		if (this.isWarZone() && this.forcedMapCharacter == null) {
+			this.forcedMapCharacter = "+".charAt(0);
+		}
+		
+		return this.forcedMapCharacter;
+	}
+	
+	public boolean hasForcedMapColour() {
+		return this.getForcedMapColour() != null;
+	}
+	
+	public void setForcedMapColour(ChatColor colour) {
+		this.forcedMapColour = colour;
+	}
+	
+	public ChatColor getForcedMapColour() {
+		if (this.isWilderness() && this.forcedMapColour == null) {
+			this.forcedMapColour = ChatColor.GRAY;
+		}
+		if (this.isSafeZone() && this.forcedMapColour == null) {
+			this.forcedMapColour = ChatColor.GOLD;
+		}
+		if (this.isWarZone() && this.forcedMapColour == null) {
+			this.forcedMapColour = ChatColor.DARK_RED;
+		}
+		
+		return this.forcedMapColour;
+	}
+	
 
 	public void setHome(Location home) {
 		this.home = new LazyLocation(home);

--- a/src/main/java/net/redstoneore/legacyfactions/util/RelationUtil.java
+++ b/src/main/java/net/redstoneore/legacyfactions/util/RelationUtil.java
@@ -4,10 +4,12 @@ import org.bukkit.ChatColor;
 
 import net.redstoneore.legacyfactions.Relation;
 import net.redstoneore.legacyfactions.RelationParticipator;
+import net.redstoneore.legacyfactions.Factions;
 import net.redstoneore.legacyfactions.Lang;
 import net.redstoneore.legacyfactions.entity.Conf;
 import net.redstoneore.legacyfactions.entity.FPlayer;
 import net.redstoneore.legacyfactions.entity.Faction;
+import net.redstoneore.legacyfactions.entity.FactionColl;
 
 public class RelationUtil {
 
@@ -105,11 +107,11 @@ public class RelationUtil {
             }
 
             if (thatFaction.isSafeZone() && thatFaction != getFaction(me)) {
-                return Conf.colorPeaceful;
+                return FactionColl.get().getSafeZone().getForcedMapColour();
             }
 
             if (thatFaction.isWarZone() && thatFaction != getFaction(me)) {
-                return Conf.colorWar;
+                return FactionColl.get().getWarZone().getForcedMapColour();
             }
         }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -290,3 +290,7 @@ permissions:
     description: Access faction vault.
   factions.setmaxvault:
     description: Set a faction's max vaults.
+  factions.style:
+    description: Change map style options.
+  factions.style.any:
+    description: Change map style options for any faction


### PR DESCRIPTION
This adds style to maps.

For example:
Change your faction to red: `/f style color RED`
Change your faction character to $: `/f style character $`
Change the wilderness character to _: `/f style character _ wilderness`
Change the wilderness colour to dark purple: `/f style color DARK_PURPLE wilderness`

Not ideal for every server obviously and should probably only be used by server ops.

Permissions:
-  factions.style: Change map style options.
-  factions.style.any: Change map style options for any faction
