### PR TITLE
Fix missing code end

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -143,7 +143,7 @@ class User {
 		...
 
 }
-
+```
 ### Include units in variable names
 
 ```java


### PR DESCRIPTION
There were missing characters to stop the code section on the STYLEGUIDE.md file.