### PR TITLE
Fix missing commands in /f help

### DIFF
--- a/src/main/java/net/redstoneore/legacyfactions/cmd/CmdFactionsHelp.java
+++ b/src/main/java/net/redstoneore/legacyfactions/cmd/CmdFactionsHelp.java
@@ -123,6 +123,10 @@ public class CmdFactionsHelp extends FCommand {
 					line = 0;
 				}
 			}
+
+			if (!lines.isEmpty()) {
+				pages.add(lines);
+			}
 			
 			this.helpPageCache.put(id, pages);
 		}


### PR DESCRIPTION
Some commands are missing in /f help:

- /f modifypower
- /f logins
- /f top
- and all the commands that others plugins register

The problem is the lines are add in the pages list only by 10, so if you have 67 lines, the 7 last lines are never add.
